### PR TITLE
Reset performance optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,11 @@ cargo test -- --include-ignored
 ```
 
 ## Notes for performance testing Reset Initialization
+
+```
 cargo asm 'chessica::reset::child::<impl chessica::reset::Reset>::init_child'
 cargo asm 'chessica::reset::child::<impl chessica::reset::Reset>::init_child' | wc -l
 cargo asm chessica::reset::new
 cargo asm chessica::reset::new | wc -l
+```
 

--- a/README.md
+++ b/README.md
@@ -51,3 +51,10 @@ To run the full integration test suite, run:
 ```
 cargo test -- --include-ignored
 ```
+
+## Notes for performance testing Reset Initialization
+cargo asm 'chessica::reset::child::<impl chessica::reset::Reset>::init_child'
+cargo asm 'chessica::reset::child::<impl chessica::reset::Reset>::init_child' | wc -l
+cargo asm chessica::reset::new
+cargo asm chessica::reset::new | wc -l
+

--- a/src/reset/child.rs
+++ b/src/reset/child.rs
@@ -52,6 +52,19 @@ impl Reset {
         child.promotion = 0;
         child.king_castled = 0;
         child.game_over = 0;
+
+        child.hash_value = 0;
+        child.min = 0;
+        child.max = 0;
+        child.bi_from = 0;
+        child.bi_to = 0;
+        child.score_depth = 0;
+        child.hash_count = 0;
+        child.times_seen = 0;
+        child.must_check_safety = 0;
+        child.reserved_12 = 0;
+        child.reserved_13 = 0;
+        child.reserved_14 = 0;
     }
 }
 

--- a/src/reset/child.rs
+++ b/src/reset/child.rs
@@ -24,12 +24,23 @@ impl Reset {
         child.b_bishops = self.b_bishops;
         child.b_rooks = self.b_rooks;
         child.b_kings = self.b_kings;
+        child.reserved_01 = self.reserved_01;
         child.material = self.material;
         child.halfmove_clock = self.halfmove_clock;
         child.fullmove_number = self.fullmove_number;
         child.white_king_square = self.white_king_square;
         child.black_king_square = self.black_king_square;
         child.castle_bits = self.castle_bits;
+        child.reserved_02 = self.reserved_02;
+        child.reserved_03 = self.reserved_03;
+        child.reserved_04 = self.reserved_04;
+        child.reserved_05 = self.reserved_05;
+        child.reserved_06 = self.reserved_06;
+        child.reserved_07 = self.reserved_07;
+        child.reserved_08 = self.reserved_08;
+        child.reserved_09 = self.reserved_09;
+        child.reserved_10 = self.reserved_10;
+        child.reserved_11 = self.reserved_11;
 
         child.b_current_piece = 0;
         child.b_en_passant = 0;
@@ -50,6 +61,7 @@ mod tests {
     #[test]
     fn reset_init_child_fen() {
         let mut r = reset::new();
+        // Note that the halfmove_clock, fullmove_number, and to_move change elsewhere
         let fen1 = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
         let fen2 = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
         let fen3 = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";

--- a/src/reset/clone.rs
+++ b/src/reset/clone.rs
@@ -24,12 +24,23 @@ impl Reset {
         clone.b_bishops = self.b_bishops;
         clone.b_rooks = self.b_rooks;
         clone.b_kings = self.b_kings;
+        clone.reserved_01 = self.reserved_01;
         clone.material = self.material;
         clone.halfmove_clock = self.halfmove_clock;
         clone.fullmove_number = self.fullmove_number;
         clone.white_king_square = self.white_king_square;
         clone.black_king_square = self.black_king_square;
         clone.castle_bits = self.castle_bits;
+        clone.reserved_02 = self.reserved_02;
+        clone.reserved_03 = self.reserved_03;
+        clone.reserved_04 = self.reserved_04;
+        clone.reserved_05 = self.reserved_05;
+        clone.reserved_06 = self.reserved_06;
+        clone.reserved_07 = self.reserved_07;
+        clone.reserved_08 = self.reserved_08;
+        clone.reserved_09 = self.reserved_09;
+        clone.reserved_10 = self.reserved_10;
+        clone.reserved_11 = self.reserved_11;
 
         clone.b_current_piece = self.b_current_piece;
         clone.b_en_passant = self.b_en_passant;

--- a/src/reset/clone.rs
+++ b/src/reset/clone.rs
@@ -64,6 +64,9 @@ impl Reset {
         clone.hash_count = self.hash_count;
         clone.times_seen = self.times_seen;
         clone.must_check_safety = self.must_check_safety;
+        clone.reserved_12 = self.reserved_12;
+        clone.reserved_13 = self.reserved_13;
+        clone.reserved_14 = self.reserved_14;
     }
 }
 

--- a/src/reset/mod.rs
+++ b/src/reset/mod.rs
@@ -93,7 +93,7 @@ pub mod profiling;
 /// | hash_count        | u8   | 1    |   30  | Number of times this reset was saved to the hash table |
 /// | times_seen        | u8   | 1    |   31  | Number of times this reset has been seen in the current game |
 /// | must_check_safety | u8   | 1    |   32  | 1 if we must check king safety after this move, 0 otherwise.  I believe this is used for odd moves, like EP captures, castling, and promotions. |
-#[repr(C)]
+///#[repr(C)]
 pub struct Reset {
     //Fields passed from parent to child
     b_all: u64,                 // 8 bytes (  8)
@@ -103,12 +103,23 @@ pub struct Reset {
     b_bishops: u64,             // 8 bytes ( 40)
     b_rooks: u64,               // 8 bytes ( 48)
     b_kings: u64,               // 8 bytes ( 56)
+    reserved_01: u64,               // 8 bytes ( 56)
     material: i8,               // 1 byte  ( 57)
     halfmove_clock: u8,         // 1 byte  ( 58)
     fullmove_number: u8,        // 1 byte  ( 59)
     white_king_square: u8,      // 1 byte  ( 60)
     black_king_square: u8,      // 1 byte  ( 61)
     castle_bits: u8,            // 1 byte  ( 62) bit
+    reserved_02: u8,            // 1 byte  ( 62) bit
+    reserved_03: u8,            // 1 byte  ( 62) bit
+    reserved_04: u8,            // 1 byte  ( 62) bit
+    reserved_05: u8,            // 1 byte  ( 62) bit
+    reserved_06: u8,            // 1 byte  ( 62) bit
+    reserved_07: u8,            // 1 byte  ( 62) bit
+    reserved_08: u8,            // 1 byte  ( 62) bit
+    reserved_09: u8,            // 1 byte  ( 62) bit
+    reserved_10: u8,            // 1 byte  ( 62) bit
+    reserved_11: u8,            // 1 byte  ( 62) bit
 
     //Fields cleared in a new child
     b_current_piece: u64,       // 8 bytes (  8)
@@ -153,12 +164,23 @@ pub fn new() -> Reset {
         b_bishops: 0,
         b_rooks: 0,
         b_kings: 0,
+        reserved_01: 0,
         material: 0,
         halfmove_clock: 0,
         fullmove_number: 0,
         white_king_square: 0,
         black_king_square: 0,
         castle_bits: 0,
+        reserved_02: 0,
+        reserved_03: 0,
+        reserved_04: 0,
+        reserved_05: 0,
+        reserved_06: 0,
+        reserved_07: 0,
+        reserved_08: 0,
+        reserved_09: 0,
+        reserved_10: 0,
+        reserved_11: 0,
 
         b_current_piece: 0,
         b_en_passant: 0,

--- a/src/reset/mod.rs
+++ b/src/reset/mod.rs
@@ -37,133 +37,122 @@ pub mod profiling;
 /// # Reset Fields
 ///
 /// Note that 128-bit blocks need to be homogeneous in order to optimize Reset child
-/// initialization.
+/// initialization.  This table indicates (via "offset") where the compiler puts each 
+/// field in the structure.
 /// 
 /// Resets contain the following fields:
 ///
-/// ## Fields passed from parent to child
-///
 /// | field             | type | child? | offset | description |
-/// | ----------------- | ---- | ------ | ----- | ----------- |
-/// | b_all             | u64  | copy   |    8  | Bitstring representing the presence of any piece |
-/// | b_white           | u64  | copy   |   16  | Bitstring representing the presence of white pieces. |
-/// |                   |      |        |       | Note that there is no `b_black` - a user must call `b_black()` to derive this value. |
-/// | b_pawns           | u64  | copy   |   24  | Bitstring representing the presence of pawns |
-/// | b_knights         | u64  | copy   |   32  | Bitstring representing the presence of knights |
-/// | b_bishops         | u64  | copy   |   40  | Bitstring representing the presence of bishops |
-/// | b_rooks           | u64  | copy   |   48  | Bitstring representing the presence of rooks |
-/// |                   |      |        |       | Note that there is no `b_queens` - a user must call `b_queens()` to derive this value. |
-/// | b_kings           | u64  | copy   |   56  | Bitstring representing the presence of kings |
-/// | reserved_01       | u64  | copy   |   64  | Reserved |
-/// | material          | i8   | copy   |   65  | Material score of this board |
-/// | halfmove_clock    | u8   | copy   |   66  | Halfmoves elapsed since last pawn move or capture |
-/// | fullmove_number   | u8   | copy   |   67  | Full moves elapsed since beginning of the game |
-/// | white_king_square | u8   | copy   |   68  | Square number of the white king |
-/// | black_king_square | u8   | copy   |   69  | Square number of the black king |
-/// | castle_bits       | u8   | copy   |   70  | `1` if white is eligible to castle queenside, `0` if not |
-/// | white_castle_k    |      |        |       | 0x01: `1` if white is eligible to castle kingside, `0` if not |
-/// | white_castle_q    |      |        |       | 0x02: `1` if white is eligible to castle queenside, `0` if not |
-/// | black_castle_k    |      |        |       | 0x04: `1` if black is eligible to castle kingside, `0` if not |
-/// | black_castle_q    |      |        |       | 0x08: `1` if black is eligible to castle queenside, `0` if not |
-/// | reserved_02       | u8   | copy   |   71  | Reserved |
-/// | reserved_03       | u8   | copy   |   72  | Reserved |
-/// | reserved_04       | u8   | copy   |   73  | Reserved |
-/// | reserved_05       | u8   | copy   |   74  | Reserved |
-/// | reserved_06       | u8   | copy   |   75  | Reserved |
-/// | reserved_07       | u8   | copy   |   76  | Reserved |
-/// | reserved_08       | u8   | copy   |   77  | Reserved |
-/// | reserved_09       | u8   | copy   |   78  | Reserved |
-/// | reserved_10       | u8   | copy   |   79  | Reserved |
-/// | reserved_11       | u8   | copy   |   80  | Reserved |
-///
-/// ## Fields cleared in a new child
-///
-/// | field             | type | child? | total | description |
-/// | ----------------- | ---- | ------ | ----- | ----------- |
-/// | b_current_piece   | u64  | clear  |    8  | Bitstring representing the piece currently under consideration for move generation |
-/// | b_en_passant      | u64  | clear  |   16  | Bitstring representing a piece that is eligible for en passant capture.  This is an entire bitstring to represent a single bit, which seems wasteful. |
-/// | score             | i32  | clear  |   20  | Score of this reset.  White is positive, Black negative.  If white is up exactly a pawn, the score will be 1,000,000.  Checkmate for Black is -128,000,000. |
-/// | move_id           | u8   | clear  |   21  | ID of tne next move to be considered for a given piece type |
-/// | to_move           | u8   | clear  |   22  | `0` if it is white's move, `1` if it is black's move |
-/// | capture           | u8   | clear  |   23  | `1` if the last move was a capture, `0` otherwise |
-/// | in_check          | u8   | clear  |   24  | `1` if the side moving is currently in check, `0` otherwise |
-/// | promotion         | u8   | clear  |   25  | `1` if the last move was a promotion, `0` otherwise |
-/// | king_castled      | u8   | clear  |   26  | `1` if the last move was a castle, `0` otherwise |
-/// | game_over         | u8   | clear  |   27  | `1` if the game is over |
-///
-///
-/// ## Fields that can be garbage in a new child
-///
-/// | field             | type | child? | total | description |
-/// | ----------------- | ---- | ------ | ----- | ----------- |
-/// | b_from            | u64  | whatev |    8  | Bitstring representing where the last piece was moved from |
-/// | b_to              | u64  | whatev |   16  | Bitstring representing where the last piece was moved to |
-/// | hash_value        | u32  | whatev |   20  | Hash value for this reset |
-/// | min               | i32  | whatev |   24  | Min value used for move searching |
-/// | max               | i32  | whatev |   28  | Max value used for move searching |
-/// | bi_from           | u8   | whatev |   29  | Bit index of the move's originating square |
-/// | bi_to             | u8   | whatev |   29  | Bit index of the move's destination square |
-/// | score_depth       | u8   | whatev |   29  | Search depth from which score was obtained |
-/// | hash_count        | u8   | whatev |   30  | Number of times this reset was saved to the hash table |
-/// | times_seen        | u8   | whatev |   31  | Number of times this reset has been seen in the current game |
-/// | must_check_safety | u8   | whatev |   32  | 1 if we must check king safety after this move, 0 otherwise.  I believe this is used for odd moves, like EP captures, castling, and promotions. |
-/// | reserved_12       | u8   | whatev |   32  | Reserved |
-/// | reserved_13       | u8   | whatev |   32  | Reserved |
-/// | reserved_14       | u8   | whatev |   32  | Reserved |
+/// | ----------------- | ---- | ------ | ------ | ----------- |
+/// | b_all             | u64  | copy   |    0   | Bitstring representing the presence of any piece |
+/// | b_white           | u64  | copy   |    8   | Bitstring representing the presence of white pieces. |
+/// |                   |      |        |        | Note that there is no `b_black` - a user must call `b_black()` to derive this value. |
+/// | b_pawns           | u64  | copy   |   16   | Bitstring representing the presence of pawns |
+/// | b_knights         | u64  | copy   |   24   | Bitstring representing the presence of knights |
+/// | b_bishops         | u64  | copy   |   32   | Bitstring representing the presence of bishops |
+/// | b_rooks           | u64  | copy   |   40   | Bitstring representing the presence of rooks |
+/// |                   |      |        |        | Note that there is no `b_queens` - a user must call `b_queens()` to derive this value. |
+/// | b_kings           | u64  | copy   |   48   | Bitstring representing the presence of kings |
+/// | reserved_01       | u64  | copy   |   56   | Reserved |
+/// | b_current_piece   | u64  | clear  |   64   | Bitstring representing the piece currently under consideration for move generation |
+/// | b_en_passant      | u64  | clear  |   72   | Bitstring representing a piece that is eligible for en passant capture.  This is an entire bitstring to represent a single bit, which seems wasteful. |
+/// | b_from            | u64  | whatev |   80   | Bitstring representing where the last piece was moved from |
+/// | b_to              | u64  | whatev |   88   | Bitstring representing where the last piece was moved to |
+/// | score             | i32  | clear  |   96   | Score of this reset.  White is positive, Black negative.  If white is up exactly a pawn, the score will be 1,000,000.  Checkmate for Black is -128,000,000. |
+/// | hash_value        | u32  | whatev |  100   | Hash value for this reset |
+/// | min               | i32  | whatev |  104   | Min value used for move searching |
+/// | max               | i32  | whatev |  108   | Max value used for move searching |
+/// | material          | i8   | copy   |  112   | Material score of this board |
+/// | halfmove_clock    | u8   | copy   |  113   | Halfmoves elapsed since last pawn move or capture |
+/// | fullmove_number   | u8   | copy   |  114   | Full moves elapsed since beginning of the game |
+/// | white_king_square | u8   | copy   |  115   | Square number of the white king |
+/// | black_king_square | u8   | copy   |  116   | Square number of the black king |
+/// | castle_bits       | u8   | copy   |  117   | `1` if white is eligible to castle queenside, `0` if not |
+/// | white_castle_k    |      |        |        | 0x01: `1` if white is eligible to castle kingside, `0` if not |
+/// | white_castle_q    |      |        |        | 0x02: `1` if white is eligible to castle queenside, `0` if not |
+/// | black_castle_k    |      |        |        | 0x04: `1` if black is eligible to castle kingside, `0` if not |
+/// | black_castle_q    |      |        |        | 0x08: `1` if black is eligible to castle queenside, `0` if not |
+/// | reserved_02       | u8   | copy   |  118   | Reserved |
+/// | reserved_03       | u8   | copy   |  119   | Reserved |
+/// | reserved_04       | u8   | copy   |  120   | Reserved |
+/// | reserved_05       | u8   | copy   |  121   | Reserved |
+/// | reserved_06       | u8   | copy   |  122   | Reserved |
+/// | reserved_07       | u8   | copy   |  123   | Reserved |
+/// | reserved_08       | u8   | copy   |  124   | Reserved |
+/// | reserved_09       | u8   | copy   |  125   | Reserved |
+/// | reserved_10       | u8   | copy   |  126   | Reserved |
+/// | reserved_11       | u8   | copy   |  127   | Reserved |
+/// | field             | type | child? | offset | description |
+/// | move_id           | u8   | clear  |  128   | ID of tne next move to be considered for a given piece type |
+/// | to_move           | u8   | clear  |  129   | `0` if it is white's move, `1` if it is black's move |
+/// | capture           | u8   | clear  |  130   | `1` if the last move was a capture, `0` otherwise |
+/// | in_check          | u8   | clear  |  131   | `1` if the side moving is currently in check, `0` otherwise |
+/// | promotion         | u8   | clear  |  132   | `1` if the last move was a promotion, `0` otherwise |
+/// | king_castled      | u8   | clear  |  133   | `1` if the last move was a castle, `0` otherwise |
+/// | game_over         | u8   | clear  |  134   | `1` if the game is over |
+/// | bi_from           | u8   | whatev |  135   | Bit index of the move's originating square |
+/// | bi_to             | u8   | whatev |  136   | Bit index of the move's destination square |
+/// | score_depth       | u8   | whatev |  137   | Search depth from which score was obtained |
+/// | hash_count        | u8   | whatev |  138   | Number of times this reset was saved to the hash table |
+/// | times_seen        | u8   | whatev |  139   | Number of times this reset has been seen in the current game |
+/// | must_check_safety | u8   | whatev |  140   | 1 if we must check king safety after this move, 0 otherwise.  I believe this is used for odd moves, like EP captures, castling, and promotions. |
+/// | reserved_12       | u8   | whatev |  141   | Reserved |
+/// | reserved_13       | u8   | whatev |  142   | Reserved |
+/// | reserved_14       | u8   | whatev |  143   | Reserved |
 pub struct Reset {
     //Fields passed from parent to child
-    b_all: u64,                 // 8 bytes (  8)
-    b_white: u64,               // 8 bytes ( 16)
-    b_pawns: u64,               // 8 bytes ( 24)
-    b_knights: u64,             // 8 bytes ( 32)
-    b_bishops: u64,             // 8 bytes ( 40)
-    b_rooks: u64,               // 8 bytes ( 48)
-    b_kings: u64,               // 8 bytes ( 56)
-    reserved_01: u64,               // 8 bytes ( 56)
-    material: i8,               // 1 byte  ( 57)
-    halfmove_clock: u8,         // 1 byte  ( 58)
-    fullmove_number: u8,        // 1 byte  ( 59)
-    white_king_square: u8,      // 1 byte  ( 60)
-    black_king_square: u8,      // 1 byte  ( 61)
-    castle_bits: u8,            // 1 byte  ( 62) bit
-    reserved_02: u8,            // 1 byte  ( 62) bit
-    reserved_03: u8,            // 1 byte  ( 62) bit
-    reserved_04: u8,            // 1 byte  ( 62) bit
-    reserved_05: u8,            // 1 byte  ( 62) bit
-    reserved_06: u8,            // 1 byte  ( 62) bit
-    reserved_07: u8,            // 1 byte  ( 62) bit
-    reserved_08: u8,            // 1 byte  ( 62) bit
-    reserved_09: u8,            // 1 byte  ( 62) bit
-    reserved_10: u8,            // 1 byte  ( 62) bit
-    reserved_11: u8,            // 1 byte  ( 62) bit
+    b_all: u64,
+    b_white: u64,
+    b_pawns: u64,
+    b_knights: u64,
+    b_bishops: u64,
+    b_rooks: u64,
+    b_kings: u64,
+    reserved_01: u64,
+    material: i8,
+    halfmove_clock: u8,
+    fullmove_number: u8,
+    white_king_square: u8,
+    black_king_square: u8,
+    castle_bits: u8,
+    reserved_02: u8,
+    reserved_03: u8,
+    reserved_04: u8,
+    reserved_05: u8,
+    reserved_06: u8,
+    reserved_07: u8,
+    reserved_08: u8,
+    reserved_09: u8,
+    reserved_10: u8,
+    reserved_11: u8,
 
     //Fields cleared in a new child
-    b_current_piece: u64,       // 8 bytes (  8)
-    b_en_passant: u64,          // 8 bytes ( 16)
-    score: i32,                 // 4 bytes ( 20)
-    move_id: u8,                // 1 byte  ( 21)
-    to_move: u8,                // 1 byte  ( 22) bit
-    capture: u8,                // 1 byte  ( 23) bit
-    in_check: u8,               // 1 byte  ( 24) bit
-    promotion: u8,              // 1 byte  ( 25) bit
-    king_castled: u8,           // 1 byte  ( 26) bit
-    game_over: u8,              // 1 byte  ( 27) bit
+    b_current_piece: u64,
+    b_en_passant: u64,
+    score: i32,
+    move_id: u8,
+    to_move: u8,
+    capture: u8,
+    in_check: u8,
+    promotion: u8,
+    king_castled: u8,
+    game_over: u8,
 
     //Fields that can be garbage in a new child
-    b_from: u64,                // 8 bytes (  8)
-    b_to: u64,                  // 8 bytes ( 16)
-    hash_value: u32,            // 4 bytes ( 20)
-    min: i32,                   // 4 bytes ( 24)
-    max: i32,                   // 4 bytes ( 28)
-    bi_from: u8,                // 1 bytes ( 29)
-    bi_to: u8,                  // 1 bytes ( 30)
-    score_depth: u8,            // 1 bytes ( 31)
-    hash_count: u8,             // 1 bytes ( 32)
-    times_seen: u8,             // 1 bytes ( 33)
-    must_check_safety: u8,      // 1 bytes ( 34) bit
-    reserved_12: u8,            // 1 byte  ( 62) bit
-    reserved_13: u8,            // 1 byte  ( 62) bit
-    reserved_14: u8,            // 1 byte  ( 62) bit
+    b_from: u64,
+    b_to: u64,
+    hash_value: u32,
+    min: i32,
+    max: i32,
+    bi_from: u8,
+    bi_to: u8,
+    score_depth: u8,
+    hash_count: u8,
+    times_seen: u8,
+    must_check_safety: u8,
+    reserved_12: u8,
+    reserved_13: u8,
+    reserved_14: u8,
 }
 
 /// Constructs a new Reset

--- a/src/reset/profiling.rs
+++ b/src/reset/profiling.rs
@@ -32,6 +32,10 @@ pub fn count_possible_games(fen: &str, depth: u8) -> u64 {
 
 pub fn burn() {
 
+    //After valid_move work shift and improved ordering of Reset fields 1: 7m43.490s
+    //After valid_move work shift and improved ordering of Reset fields 2: 7m41.849s
+    //After valid_move work shift and improved ordering of Reset fields 3: 7m42.087s
+ 
     //After castle_bits and forced reset ordering 1: 7m49.908s
     //After castle_bits and forced reset ordering 2: 7m45.630s
     //After castle_bits and forced reset ordering 3: 7m46.438s

--- a/src/reset/profiling.rs
+++ b/src/reset/profiling.rs
@@ -32,9 +32,9 @@ pub fn count_possible_games(fen: &str, depth: u8) -> u64 {
 
 pub fn burn() {
 
-    //After valid_move work shift and improved ordering of Reset fields 1: 7m43.490s
-    //After valid_move work shift and improved ordering of Reset fields 2: 7m41.849s
-    //After valid_move work shift and improved ordering of Reset fields 3: 7m42.087s
+    //After valid_move work shift and improved ordering of Reset fields 1: 7m37.862s
+    //After valid_move work shift and improved ordering of Reset fields 2: 7m41.491s
+    //After valid_move work shift and improved ordering of Reset fields 3: 7m46.781s
  
     //After castle_bits and forced reset ordering 1: 7m49.908s
     //After castle_bits and forced reset ordering 2: 7m45.630s


### PR DESCRIPTION
Adjust Reset fields to optimize Rest child initialization.  Reset initialization is down to 13 instructions, while Reset child initialization is 16 instructions.  Big improvement!

This also gives me space (via reserved fields) going forward to add data to the Reset where necessary.